### PR TITLE
Create chain-hash.json

### DIFF
--- a/client/chain-hash.json
+++ b/client/chain-hash.json
@@ -1,4 +1,4 @@
 {
-  "chain.acc.zip": "ec3be4ba258193e342b90fa8a634e938",
+  "chain.acc.zip": "48f887bf123108da7821c4dee542b8ac",
   "chain.acc.test.zip": "87aaf2bfb0c233c97cb42789b148764d"
 }

--- a/client/chain-hash.json
+++ b/client/chain-hash.json
@@ -1,0 +1,4 @@
+{
+  "chain.acc.zip": "ec3be4ba258193e342b90fa8a634e938",
+  "chain.acc.test.zip": "87aaf2bfb0c233c97cb42789b148764d"
+}


### PR DESCRIPTION
md5 hash for chain.acc.zip and chain.acc.test.zip currently hosted on neo.org

This file will be required to exist on https://neo.org/client/chain-hash.json for the new bootstrap downloader to work: https://github.com/neo-project/neo-gui/issues/55

The url is however configurable in neo-gui/config.json