### PR TITLE
Change slack invite url to invite system

### DIFF
--- a/NeoWeb/Views/Shared/_Layout.cshtml
+++ b/NeoWeb/Views/Shared/_Layout.cshtml
@@ -74,7 +74,7 @@
                         <li><span class="iconfont">&#xe6ed;</span><a target="_blank" href="https://github.com/neo-project">GitHub</a></li>
                         <li><span class="iconfont">&#xe681;</span><a target="_blank" href="https://www.facebook.com/NEOSmartEcon/">Facebook</a></li>
                         <li><span class="iconfont">&#xe601;</span><a target="_blank" href="https://twitter.com/neo_blockchain">Twitter</a></li>
-                        <li><span class="iconfont">&#xeaa2;</span><a target="_blank" href="https://join.slack.com/t/neosmarteconomy/shared_invite/enQtMjYyMjg4Nzc2MDUzLTNmZGEyMzAzMjBmM2YwNjBlNDc0MjBjNTVmMGYwMTY3NjY1Yzc1MGY3MGY1M2YzN2NjMmU5ZDE5MGIzNzFjNzk">slack</a></li>
+                        <li><span class="iconfont">&#xeaa2;</span><a target="_blank" href="https://slack-helper.cityofzion.io/invite/T656BRXQ8">slack</a></li>
                         <li><span class="iconfont">&#xe7d9;</span><a target="_blank" href="https://www.reddit.com/r/NEO/">Reddit</a></li>
                         <li><span class="iconfont">&#xe604;</span><a target="_blank" href="https://shang.qq.com/wpa/qunwpa?idkey=7a70d15ce55b94c5cc93d8dffd074316f40d44c243a998e9128f8712deca934b">QQ</a></li>
                         <li><span class="iconfont">&#xe64a;</span><a target="_blank" href="https://weibo.com/neosmarteconomy">@Localizer["Weibo"]</a></li>


### PR DESCRIPTION
Change the slack invite URL to our private invite system to manage who joins in a better way.
This also makes it harder for bots to join.