### PR TITLE
Fixed capitalization in page title

### DIFF
--- a/NeoWeb/Views/Shared/_Layout.cshtml
+++ b/NeoWeb/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <meta name="application-name" content="neo.org">
     <meta name="renderer" content="ie-stand">
 
-    <title>@Localizer["NEO Smart economy"]</title>
+    <title>@Localizer["NEO Smart Economy"]</title>
 
     <link rel="apple-touch-icon" href="~/images/favicon.png">
     <link rel="shortcut icon" type="image/x-icon" href="~/images/favicon.png">


### PR DESCRIPTION
Not sure if was the right place for this fix. The current page title with incorrect capitalization looks amateurish.