### PR TITLE
Set word-break to normal

### DIFF
--- a/NeoWeb/wwwroot/css/dapps.css
+++ b/NeoWeb/wwwroot/css/dapps.css
@@ -12,7 +12,7 @@
     border: 1px solid #fff;
     border-style: none solid;
     text-align: center;
-    word-break: break-all;
+    word-break: normal;
     line-height: 1.5;
     background-color: #fff;
     overflow: hidden;


### PR DESCRIPTION
wordbreak: break-all property breaks words in letters. In English it is better to move the word to a new line (which is done with the normal property).  I am not aware of Chinese writing rules, so perhaps this is different en should have a setting that depends on language.