### PR TITLE
point neo-plugins link to general releases page

### DIFF
--- a/NeoWeb/Views/Client/Index.cshtml
+++ b/NeoWeb/Views/Client/Index.cshtml
@@ -57,7 +57,7 @@
                     - @Localizer["Clients with complete blockchain data"]<br />
                     - @Localizer["Provided API support and consensus function"]<br />
                     - <a href="http://sync.ngd.network/" target="_blank">@Localizer["Download offline synchronized package"]</a><br />
-                    - <a href="https://github.com/neo-project/neo-plugins/releases/tag/v2.9.0" target="_blank">@Localizer["Download plugin"]</a><br />
+                    - <a href="https://github.com/neo-project/neo-plugins/releases/" target="_blank">@Localizer["Download plugin"]</a><br />
                     - <a href="@Localizer["http://docs.neo.org/en-us/node/cli/setup.html"]" target="_blank">@Localizer["Instructions for use"]</a><br />
                     - <a href="https://github.com/neo-project/neo-cli/blob/master/CHANGELOG.md" target="_blank">@Localizer["Changelog"]</a><br />
                     - @Localizer["Support"] NEP-5, NEP-6 <br />


### PR DESCRIPTION
The https://neo.org/client page has a link to `neo-plugins` for the `neo-cli` client. This link points to a specific release (2.9.0) which can lead to confusion. When you download the latest `neo-cli` (at this moment it is `2.9.3`), then click the plugins link to download plugins, if you are not careful you will download `neo-plugins` for version `2.9.0` instead of the latest version (`2.9.3` at this moment). The link should point to the releases (where the latest will always be on top of the page.) 