### PR TITLE
Fix broken links in Developer > Examples / Turtorials

### DIFF
--- a/NeoWeb/Views/Dev/_ExamplesPartial.cshtml
+++ b/NeoWeb/Views/Dev/_ExamplesPartial.cshtml
@@ -23,7 +23,7 @@
 </div>
 
 <div class="examples">
-    <a class="example" data-type="example" data-language="python" data-version="neo3" target="_blank" href="https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/HelloWorld.py">
+    <a class="example" data-type="example" data-language="python" data-version="neo3" target="_blank" href="https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/hello_world.py">
         <div class="example-start">
             <div class="example-img-wrapper">
                 <img class="example-img" src="@Helper.ToCDN("/images/transparent.png")" data-original="@Helper.ToCDN("/images/dev/example.png", true)" />
@@ -47,7 +47,7 @@
             </div>
         </div>
     </a>
-    <a class="example" data-type="example" data-language="python" data-version="neo3" target="_blank" href="https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/NEP17.py">
+    <a class="example" data-type="example" data-language="python" data-version="neo3" target="_blank" href="https://github.com/CityOfZion/neo3-boa/blob/development/boa3_test/examples/nep17.py">
         <div class="example-start">
             <div class="example-img-wrapper">
                 <img class="example-img" src="@Helper.ToCDN("/images/transparent.png")" data-original="@Helper.ToCDN("/images/dev/example.png", true)" />
@@ -215,7 +215,7 @@
             </div>
         </div>
     </a>
-    <a class="example hidden" data-type="example" data-language="java" data-version="neo3" target="_blank" href="https://github.com/neow3j/neow3j-examples-java/blob/master/neo-n3-examples/src/main/java/io/neow3j/examples/contractdevelopment/contracts/FungibleToken.java">
+    <a class="example hidden" data-type="example" data-language="java" data-version="neo3" target="_blank" href="https://github.com/neow3j/neow3j-examples-java/blob/master/src/main/java/io/neow3j/examples/contractdevelopment/contracts/FungibleToken.java">
         <div class="example-start">
             <div class="example-img-wrapper">
                 <img class="example-img" src="@Helper.ToCDN("/images/transparent.png")" data-original="@Helper.ToCDN("/images/dev/example.png", true)" />


### PR DESCRIPTION
All three links were broken, mostly related to file naming. Have all been fixed in this PR